### PR TITLE
Minor fixes

### DIFF
--- a/cmm-mode.el
+++ b/cmm-mode.el
@@ -28,10 +28,6 @@
 ;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 ;; OF THE POSSIBILITY OF SUCH DAMAGE.
 
-(defvar cmm-mode-hook nil)
-
-(add-to-list 'auto-mode-alist '("\\.cmm\\'" . cmm-mode))
-
 (defvar cmm-keywords
   '("aborts" "align" "aligned" "also" "as" "big" "bits" "byteorder" "case"
     "const," "continuation" "cut" "cuts" "else" "equal" "export" "foreign"
@@ -61,12 +57,18 @@
     st)
   "Syntax table for cmm-mode")
 
-;; define the mode
-(define-derived-mode cmm-mode fundamental-mode
+(defalias 'cmm-parent-mode
+  (if (fboundp 'prog-mode) 'prog-mode 'fundamental-mode))
+
+;;;###autoload
+(define-derived-mode cmm-mode cmm-parent-mode
   "Cmm"
   "A major mode for editing Cmm files."
 
   ;; code for syntax highlighting
   (setq font-lock-defaults cmm-font-lock-defaults))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.cmm\\'" . cmm-mode))
 
 (provide 'cmm-mode)


### PR DESCRIPTION
- Autoload the mode definition and auto-mode-alist entry
- No need to declare the hook: define-derived-mode does this
- Use prog-mode as the parent mode in recent Emacsen
